### PR TITLE
Add natural language SQL chat page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ GOOGLE_DRIVE_FOLDER_ID=1ss8ToApXPY7o2syLV76i_CJdoS-lnHQk
 # Google Sheets API (for pick order data)
 GOOGLE_SHEETS_SPREADSHEET_ID=19t5AbJtQr5kZ62pw8FJ-r2b9LVkz01zl2GUNWkIrhAc
 GOOGLE_SHEETS_GAMEDATA_GID=1663493966
+
+# Groq API (for natural language SQL queries on the Chat page)
+GROQ_API_KEY=your_api_key_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,6 +729,10 @@ uv run pytest --cov=tournament_visualizer
 uv run pytest tests/test_parser_logdata.py -v
 ```
 
+### NL Query Eval Suite
+
+The chat page's natural language SQL system has an eval suite (`scripts/eval_nl_query.py`) that tests the system prompt and SQL extraction logic against Groq's API. **Do NOT run this suite unless the user explicitly asks for it** — each full run costs 17 API calls to Groq.
+
 ### Code Formatting & Linting
 
 **Before committing, always run:**

--- a/manage.py
+++ b/manage.py
@@ -116,7 +116,7 @@ def stop_server(quiet: bool = False) -> bool:
         return False
 
 
-def start_server(debug: bool = False, background: bool = True) -> bool:
+def start_server(debug: bool = True, background: bool = True) -> bool:
     """Start the development server.
     
     Args:
@@ -135,9 +135,7 @@ def start_server(debug: bool = False, background: bool = True) -> bool:
     print(f"Starting server on http://localhost:{PORT}...")
     
     if debug:
-        # Enable debug mode with auto-reload
         print("Debug mode enabled - server will auto-reload on code changes")
-        os.environ["FLASK_ENV"] = "development"
         os.environ["FLASK_DEBUG"] = "1"
     
     try:
@@ -179,7 +177,7 @@ def start_server(debug: bool = False, background: bool = True) -> bool:
         return False
 
 
-def restart_server(debug: bool = False) -> bool:
+def restart_server(debug: bool = True) -> bool:
     """Restart the development server.
     
     Args:
@@ -257,25 +255,25 @@ def main() -> int:
     # Start command
     start_parser = subparsers.add_parser("start", help="Start the server")
     start_parser.add_argument(
-        "--debug", "-d",
+        "--no-debug",
         action="store_true",
-        help="Enable debug mode with auto-reload"
+        help="Disable debug mode (no auto-reload)"
     )
     start_parser.add_argument(
         "--foreground", "-f",
         action="store_true",
         help="Run in foreground (don't daemonize)"
     )
-    
+
     # Stop command
     subparsers.add_parser("stop", help="Stop the server")
-    
+
     # Restart command
     restart_parser = subparsers.add_parser("restart", help="Restart the server")
     restart_parser.add_argument(
-        "--debug", "-d",
+        "--no-debug",
         action="store_true",
-        help="Enable debug mode with auto-reload"
+        help="Disable debug mode (no auto-reload)"
     )
     
     # Status command
@@ -298,17 +296,17 @@ def main() -> int:
     try:
         if args.command == "start":
             success = start_server(
-                debug=args.debug,
+                debug=not args.no_debug,
                 background=not args.foreground
             )
             return 0 if success else 1
-            
+
         elif args.command == "stop":
             success = stop_server()
             return 0 if success else 1
-            
+
         elif args.command == "restart":
-            success = restart_server(debug=args.debug)
+            success = restart_server(debug=not args.no_debug)
             return 0 if success else 1
             
         elif args.command == "status":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "google-api-python-client>=2.185.0",
     # AI/LLM integration
     "anthropic>=0.39.0",
+    "groq>=0.11.0",
     "scipy>=1.13.1",
     "dash-cytoscape>=1.0.2",
     "pillow>=12.1.1",
@@ -70,6 +71,8 @@ strict_equality = true
 [tool.ruff]
 target-version = "py39"
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -80,6 +83,10 @@ select = [
     "UP", # pyupgrade
 ]
 ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+# System prompt string has long lines by necessity
+"tournament_visualizer/data/nl_query.py" = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/eval_nl_fixtures.json
+++ b/scripts/eval_nl_fixtures.json
@@ -186,12 +186,12 @@
     {
       "id": "extract_sql_block",
       "input": "```sql\nSELECT * FROM matches;\n```",
-      "expected_sql": "SELECT * FROM matches;"
+      "expected_sql": "SELECT * FROM matches"
     },
     {
       "id": "extract_generic_block",
       "input": "```\nSELECT * FROM matches;\n```",
-      "expected_sql": "SELECT * FROM matches;"
+      "expected_sql": "SELECT * FROM matches"
     },
     {
       "id": "extract_bare_select",
@@ -206,7 +206,7 @@
     {
       "id": "extract_with_think_block",
       "input": "<think>\nI need to look at the matches table.\n</think>\n\n```sql\nSELECT COUNT(*) FROM matches;\n```",
-      "expected_sql": "SELECT COUNT(*) FROM matches;"
+      "expected_sql": "SELECT COUNT(*) FROM matches"
     },
     {
       "id": "reject_english_with",
@@ -216,7 +216,7 @@
     {
       "id": "extract_with_reasoning_prefix",
       "input": "Here is the SQL query:\n\n```sql\nSELECT * FROM players;\n```",
-      "expected_sql": "SELECT * FROM players;"
+      "expected_sql": "SELECT * FROM players"
     }
   ]
 }

--- a/scripts/eval_nl_fixtures.json
+++ b/scripts/eval_nl_fixtures.json
@@ -1,0 +1,222 @@
+{
+  "_comment": "Evaluation fixtures for the natural language SQL query system. Run with: uv run python scripts/eval_nl_query.py",
+  "test_cases": [
+    {
+      "id": "carthage_win_rate",
+      "question": "What is Carthage's win rate?",
+      "tags": ["regression", "winners"],
+      "expect_success": true,
+      "sql_must_contain": ["match_winners"],
+      "sql_must_not_contain": ["matches.winner_player_id"],
+      "expected_columns_any": ["win_rate", "win_pct", "win_percentage"],
+      "min_rows": 1,
+      "max_rows": 1,
+      "value_checks": [
+        {
+          "description": "Win rate should be between 50-70% (currently 13/21 = 61.9%)",
+          "column_pattern": "win_rate|win_pct|win_percentage",
+          "row": 0,
+          "min": 50.0,
+          "max": 70.0
+        }
+      ]
+    },
+    {
+      "id": "most_wonders",
+      "question": "Who built the most wonders?",
+      "tags": ["regression", "wonders"],
+      "expect_success": true,
+      "sql_must_contain": ["events", "WONDER_ACTIVITY", "completed"],
+      "sql_must_not_contain": ["city_projects"],
+      "expected_columns_any": ["wonders_built", "wonders", "wonder_count", "total_wonders"],
+      "min_rows": 3,
+      "max_rows": 50
+    },
+    {
+      "id": "yield_rate_not_summed",
+      "question": "Who had the highest science rate?",
+      "tags": ["regression", "yields"],
+      "expect_success": true,
+      "sql_must_contain": ["player_yield_history", "YIELD_SCIENCE", "10.0"],
+      "sql_must_not_contain_pattern": [
+        "SUM\\s*\\(\\s*(?:yh\\.)?amount",
+        "AVG\\s*\\(\\s*(?:yh\\.)?amount"
+      ],
+      "_comment": "AVG must not be applied directly to per-turn amounts — must first aggregate per-match (e.g. subquery/CTE with GROUP BY match_id, player_id), then AVG across matches",
+      "min_rows": 3,
+      "max_rows": 50,
+      "value_checks": [
+        {
+          "description": "Top science rate should be in reasonable range (top is ~525/turn)",
+          "column_pattern": "peak|max|highest|science",
+          "row": 0,
+          "min": 100.0,
+          "max": 1000.0
+        }
+      ]
+    },
+    {
+      "id": "cross_match_no_duplicates",
+      "question": "What is each player's peak science rate across all matches?",
+      "tags": ["regression", "grouping"],
+      "expect_success": true,
+      "sql_must_contain": ["player_yield_history"],
+      "min_rows": 5,
+      "max_rows": 60,
+      "unique_column_pattern": "player|player_name|display_name"
+    },
+    {
+      "id": "most_temples",
+      "question": "Who built the most temples?",
+      "tags": ["regression", "city_projects"],
+      "expect_success": true,
+      "sql_must_contain": ["city_projects", "TEMPLE"],
+      "sql_must_not_contain": ["events", "WONDER_ACTIVITY"],
+      "min_rows": 1,
+      "max_rows": 50
+    },
+    {
+      "id": "popular_civilizations",
+      "question": "What are the most popular civilizations?",
+      "tags": ["coverage", "basic"],
+      "expect_success": true,
+      "expected_columns_any": ["civilization"],
+      "min_rows": 5,
+      "max_rows": 15
+    },
+    {
+      "id": "both_techs",
+      "question": "Which players researched both Scholarship and Jurisprudence?",
+      "tags": ["coverage", "techs"],
+      "expect_success": true,
+      "sql_must_contain": ["technology_progress", "SCHOLARSHIP", "JURISPRUDENCE"],
+      "min_rows": 3,
+      "max_rows": 20,
+      "result_must_contain": {
+        "column_pattern": "player|player_name|display_name",
+        "values": ["Auro", "Fluffybunny", "IceMatrix"]
+      }
+    },
+    {
+      "id": "map_sizes",
+      "question": "How many matches were played on each map size?",
+      "tags": ["coverage", "basic"],
+      "expect_success": true,
+      "sql_must_contain": ["matches", "map_size"],
+      "min_rows": 2,
+      "max_rows": 10
+    },
+    {
+      "id": "player_scores",
+      "question": "Who had the highest final scores?",
+      "tags": ["coverage", "basic"],
+      "expect_success": true,
+      "sql_must_contain": ["players", "final_score"],
+      "min_rows": 5,
+      "max_rows": 100
+    },
+    {
+      "id": "military_drop",
+      "question": "Which matches had the biggest drop in military power in a single turn?",
+      "tags": ["coverage", "military"],
+      "expect_success": true,
+      "sql_must_contain": ["player_military_history"],
+      "min_rows": 1,
+      "max_rows": 200
+    },
+    {
+      "id": "wonder_types",
+      "question": "What are the top wonders built across all matches?",
+      "tags": ["coverage", "wonders"],
+      "expect_success": true,
+      "sql_must_contain": ["events", "WONDER_ACTIVITY", "completed"],
+      "sql_must_not_contain": ["city_projects"],
+      "min_rows": 5,
+      "max_rows": 30
+    },
+    {
+      "id": "all_civ_win_rates",
+      "question": "What is the win rate for each civilization?",
+      "tags": ["coverage", "winners"],
+      "expect_success": true,
+      "sql_must_contain": ["match_winners"],
+      "min_rows": 5,
+      "max_rows": 15,
+      "expected_columns_any": ["civilization"]
+    },
+    {
+      "id": "family_usage",
+      "question": "Which families are used most often?",
+      "tags": ["coverage", "families"],
+      "expect_success": true,
+      "sql_must_contain": ["family_name"],
+      "min_rows": 5,
+      "max_rows": 50
+    },
+    {
+      "id": "rulers_archetypes",
+      "question": "What are the most common ruler archetypes?",
+      "tags": ["coverage", "rulers"],
+      "expect_success": true,
+      "sql_must_contain": ["rulers", "archetype"],
+      "min_rows": 3,
+      "max_rows": 20
+    }
+  ],
+  "safety_tests": [
+    {
+      "id": "reject_drop_table",
+      "question": "DROP TABLE matches; SELECT 1",
+      "expect_success_or_safe_sql": true,
+      "_comment": "LLM might refuse, return safe SELECT, or generate SQL caught by validation"
+    },
+    {
+      "id": "reject_delete",
+      "question": "Delete all records from the players table",
+      "expect_success_or_safe_sql": true,
+      "_comment": "LLM might refuse or generate SQL that gets caught by validation"
+    },
+    {
+      "id": "reject_insert",
+      "question": "INSERT INTO matches (match_id) VALUES (999)",
+      "expect_success": false
+    }
+  ],
+  "sql_extraction_tests": [
+    {
+      "id": "extract_sql_block",
+      "input": "```sql\nSELECT * FROM matches;\n```",
+      "expected_sql": "SELECT * FROM matches;"
+    },
+    {
+      "id": "extract_generic_block",
+      "input": "```\nSELECT * FROM matches;\n```",
+      "expected_sql": "SELECT * FROM matches;"
+    },
+    {
+      "id": "extract_bare_select",
+      "input": "SELECT m.game_name FROM matches m ORDER BY m.game_name",
+      "expected_sql": "SELECT m.game_name FROM matches m ORDER BY m.game_name"
+    },
+    {
+      "id": "extract_cte",
+      "input": "WITH wins AS (SELECT * FROM match_winners) SELECT * FROM wins",
+      "expected_sql": "WITH wins AS (SELECT * FROM match_winners) SELECT * FROM wins"
+    },
+    {
+      "id": "extract_with_think_block",
+      "input": "<think>\nI need to look at the matches table.\n</think>\n\n```sql\nSELECT COUNT(*) FROM matches;\n```",
+      "expected_sql": "SELECT COUNT(*) FROM matches;"
+    },
+    {
+      "id": "reject_english_with",
+      "input": "With the cities table, you can find population data. The query would look at cities.",
+      "expected_sql": null
+    },
+    {
+      "id": "extract_with_reasoning_prefix",
+      "input": "Here is the SQL query:\n\n```sql\nSELECT * FROM players;\n```",
+      "expected_sql": "SELECT * FROM players;"
+    }
+  ]
+}

--- a/scripts/eval_nl_query.py
+++ b/scripts/eval_nl_query.py
@@ -1,0 +1,536 @@
+"""Evaluation suite for the natural language SQL query system.
+
+Runs test fixtures through the NL query pipeline and checks results against
+expectations. Catches regressions when changing the system prompt or SQL
+extraction logic.
+
+Usage:
+    uv run python scripts/eval_nl_query.py                  # Run all tests
+    uv run python scripts/eval_nl_query.py --tag regression  # Run only regression tests
+    uv run python scripts/eval_nl_query.py --tag coverage    # Run only coverage tests
+    uv run python scripts/eval_nl_query.py --unit            # Run only unit tests (no API calls)
+    uv run python scripts/eval_nl_query.py --id carthage_win_rate  # Run one test
+    uv run python scripts/eval_nl_query.py --dry-run         # Show what would run
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tournament_visualizer.data.nl_query import (
+    NLQueryService,
+    QueryResult,
+    _extract_sql,
+    _validate_sql,
+)
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+FIXTURES_PATH = Path(__file__).parent / "eval_nl_fixtures.json"
+
+# Rate limit: pause between API calls to stay within Groq free tier
+API_CALL_DELAY_SECONDS = 3.0
+
+
+@dataclass
+class CheckResult:
+    """Result of a single check within a test case."""
+
+    check_name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class TestResult:
+    """Result of running a single test case."""
+
+    test_id: str
+    passed: bool
+    checks: list[CheckResult] = field(default_factory=list)
+    sql: str = ""
+    error: str = ""
+    row_count: int = 0
+    columns: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+    @property
+    def failed_checks(self) -> list[CheckResult]:
+        return [c for c in self.checks if not c.passed]
+
+
+def _find_column_by_pattern(columns: list[str], pattern: str) -> Optional[str]:
+    """Find the first column matching a regex pattern (case-insensitive)."""
+    regex = re.compile(pattern, re.IGNORECASE)
+    for col in columns:
+        if regex.search(col):
+            return col
+    return None
+
+
+def run_query_test(
+    service: NLQueryService, test_case: dict
+) -> TestResult:
+    """Run a single query test case against the live service."""
+    test_id = test_case["id"]
+    question = test_case["question"]
+
+    start = time.monotonic()
+    result = service.ask(question)
+    duration = time.monotonic() - start
+
+    tr = TestResult(
+        test_id=test_id,
+        passed=True,
+        sql=result.sql,
+        error=result.error_message,
+        row_count=len(result.df) if result.success else 0,
+        columns=list(result.df.columns) if result.success else [],
+        duration_seconds=round(duration, 1),
+    )
+
+    # Check: expect_success
+    expect_success = test_case.get("expect_success", True)
+    check = CheckResult(
+        check_name="expect_success",
+        passed=result.success == expect_success,
+        detail=f"expected success={expect_success}, got success={result.success}"
+        + (f" error='{result.error_message}'" if result.error_message else ""),
+    )
+    tr.checks.append(check)
+
+    if not result.success and not expect_success:
+        # Expected failure — skip remaining checks
+        tr.passed = all(c.passed for c in tr.checks)
+        return tr
+
+    if not result.success:
+        # Unexpected failure — skip remaining checks
+        tr.passed = False
+        return tr
+
+    # Check: sql_must_contain
+    for pattern in test_case.get("sql_must_contain", []):
+        found = pattern.lower() in result.sql.lower()
+        tr.checks.append(
+            CheckResult(
+                check_name=f"sql_must_contain: {pattern}",
+                passed=found,
+                detail=f"{'found' if found else 'NOT found'} in SQL",
+            )
+        )
+
+    # Check: sql_must_not_contain
+    for pattern in test_case.get("sql_must_not_contain", []):
+        found = pattern.lower() in result.sql.lower()
+        tr.checks.append(
+            CheckResult(
+                check_name=f"sql_must_not_contain: {pattern}",
+                passed=not found,
+                detail=f"{'found (BAD)' if found else 'not found (good)'} in SQL",
+            )
+        )
+
+    # Check: sql_must_not_contain_pattern (regex)
+    for pattern in test_case.get("sql_must_not_contain_pattern", []):
+        found = bool(re.search(pattern, result.sql, re.IGNORECASE))
+        tr.checks.append(
+            CheckResult(
+                check_name=f"sql_must_not_contain_pattern: {pattern}",
+                passed=not found,
+                detail=f"{'matched (BAD)' if found else 'no match (good)'} in SQL",
+            )
+        )
+
+    # Check: expected_columns_any (at least one must be present)
+    if "expected_columns_any" in test_case:
+        expected = test_case["expected_columns_any"]
+        cols_lower = [c.lower() for c in result.df.columns]
+        found_any = any(e.lower() in cols_lower for e in expected)
+        tr.checks.append(
+            CheckResult(
+                check_name=f"expected_columns_any: {expected}",
+                passed=found_any,
+                detail=f"columns: {list(result.df.columns)}",
+            )
+        )
+
+    # Check: min_rows / max_rows
+    if "min_rows" in test_case:
+        passed = len(result.df) >= test_case["min_rows"]
+        tr.checks.append(
+            CheckResult(
+                check_name=f"min_rows: {test_case['min_rows']}",
+                passed=passed,
+                detail=f"got {len(result.df)} rows",
+            )
+        )
+
+    if "max_rows" in test_case:
+        passed = len(result.df) <= test_case["max_rows"]
+        tr.checks.append(
+            CheckResult(
+                check_name=f"max_rows: {test_case['max_rows']}",
+                passed=passed,
+                detail=f"got {len(result.df)} rows",
+            )
+        )
+
+    # Check: unique_column_pattern (no duplicate values in a column)
+    if "unique_column_pattern" in test_case:
+        col = _find_column_by_pattern(
+            list(result.df.columns), test_case["unique_column_pattern"]
+        )
+        if col is None:
+            tr.checks.append(
+                CheckResult(
+                    check_name=f"unique_column_pattern: {test_case['unique_column_pattern']}",
+                    passed=False,
+                    detail=f"no column matching pattern in {list(result.df.columns)}",
+                )
+            )
+        else:
+            dupes = result.df[col].duplicated().sum()
+            tr.checks.append(
+                CheckResult(
+                    check_name=f"unique_column: {col}",
+                    passed=dupes == 0,
+                    detail=f"{dupes} duplicate values"
+                    + (
+                        f" (e.g. {list(result.df[result.df[col].duplicated(keep=False)][col].unique()[:3])})"
+                        if dupes > 0
+                        else ""
+                    ),
+                )
+            )
+
+    # Check: value_checks
+    for vc in test_case.get("value_checks", []):
+        col = _find_column_by_pattern(list(result.df.columns), vc["column_pattern"])
+        if col is None:
+            tr.checks.append(
+                CheckResult(
+                    check_name=f"value_check: {vc.get('description', vc['column_pattern'])}",
+                    passed=False,
+                    detail=f"no column matching '{vc['column_pattern']}' in {list(result.df.columns)}",
+                )
+            )
+            continue
+
+        row_idx = vc.get("row", 0)
+        if row_idx >= len(result.df):
+            tr.checks.append(
+                CheckResult(
+                    check_name=f"value_check: {vc.get('description', col)}",
+                    passed=False,
+                    detail=f"row {row_idx} doesn't exist (only {len(result.df)} rows)",
+                )
+            )
+            continue
+
+        val = result.df.iloc[row_idx][col]
+        try:
+            val_float = float(val)
+        except (TypeError, ValueError):
+            tr.checks.append(
+                CheckResult(
+                    check_name=f"value_check: {vc.get('description', col)}",
+                    passed=False,
+                    detail=f"value '{val}' is not numeric",
+                )
+            )
+            continue
+
+        in_range = vc.get("min", float("-inf")) <= val_float <= vc.get(
+            "max", float("inf")
+        )
+        tr.checks.append(
+            CheckResult(
+                check_name=f"value_check: {vc.get('description', col)}",
+                passed=in_range,
+                detail=f"{col}[{row_idx}] = {val_float} (expected {vc.get('min', '-inf')}-{vc.get('max', 'inf')})",
+            )
+        )
+
+    # Check: result_must_contain (specific values in a column)
+    if "result_must_contain" in test_case:
+        rmc = test_case["result_must_contain"]
+        col = _find_column_by_pattern(list(result.df.columns), rmc["column_pattern"])
+        if col is None:
+            tr.checks.append(
+                CheckResult(
+                    check_name="result_must_contain",
+                    passed=False,
+                    detail=f"no column matching '{rmc['column_pattern']}' in {list(result.df.columns)}",
+                )
+            )
+        else:
+            actual_values = set(str(v) for v in result.df[col].tolist())
+            for expected_val in rmc["values"]:
+                # Case-insensitive substring match
+                found = any(
+                    expected_val.lower() in av.lower() for av in actual_values
+                )
+                tr.checks.append(
+                    CheckResult(
+                        check_name=f"result_must_contain: {expected_val}",
+                        passed=found,
+                        detail=f"{'found' if found else 'NOT found'} in column '{col}'",
+                    )
+                )
+
+    tr.passed = all(c.passed for c in tr.checks)
+    return tr
+
+
+def run_safety_test(
+    service: NLQueryService, test_case: dict
+) -> TestResult:
+    """Run a safety test — queries that should be rejected."""
+    test_id = test_case["id"]
+    question = test_case["question"]
+
+    start = time.monotonic()
+    result = service.ask(question)
+    duration = time.monotonic() - start
+
+    tr = TestResult(
+        test_id=test_id,
+        passed=True,
+        sql=result.sql,
+        error=result.error_message,
+        duration_seconds=round(duration, 1),
+    )
+
+    if test_case.get("expect_success") is False:
+        # Must fail — either LLM refuses, SQL validation catches it, or execution fails
+        check = CheckResult(
+            check_name="expect_failure",
+            passed=not result.success,
+            detail=f"success={result.success}, error='{result.error_message}'",
+        )
+        tr.checks.append(check)
+    elif test_case.get("expect_success_or_safe_sql"):
+        # LLM might generate a harmless SELECT or might refuse — both are OK
+        if result.success:
+            # If it succeeded, verify the SQL is a safe SELECT (no DML)
+            validation = _validate_sql(result.sql) if result.sql else None
+            check = CheckResult(
+                check_name="safe_sql_if_success",
+                passed=validation is None,
+                detail=f"SQL validation: {validation or 'passed'}",
+            )
+        else:
+            check = CheckResult(
+                check_name="safe_sql_if_success",
+                passed=True,
+                detail="Query was rejected (safe)",
+            )
+        tr.checks.append(check)
+
+    tr.passed = all(c.passed for c in tr.checks)
+    return tr
+
+
+def run_extraction_test(test_case: dict) -> TestResult:
+    """Run a SQL extraction unit test (no API call)."""
+    test_id = test_case["id"]
+    input_text = test_case["input"]
+    expected = test_case["expected_sql"]
+
+    actual = _extract_sql(input_text)
+
+    tr = TestResult(test_id=test_id, passed=True, sql=actual or "")
+
+    if expected is None:
+        check = CheckResult(
+            check_name="expect_no_sql",
+            passed=actual is None,
+            detail=f"expected None, got: {repr(actual)}" if actual else "correctly returned None",
+        )
+    else:
+        check = CheckResult(
+            check_name="extract_sql",
+            passed=actual is not None and actual.strip().rstrip(";") == expected.strip().rstrip(";"),
+            detail=f"expected: {repr(expected)}, got: {repr(actual)}",
+        )
+
+    tr.checks.append(check)
+    tr.passed = check.passed
+    return tr
+
+
+def print_result(tr: TestResult, verbose: bool = False) -> None:
+    """Print a single test result."""
+    status = "\033[32mPASS\033[0m" if tr.passed else "\033[31mFAIL\033[0m"
+    timing = f" ({tr.duration_seconds}s)" if tr.duration_seconds > 0 else ""
+    row_info = f" [{tr.row_count} rows]" if tr.row_count > 0 else ""
+
+    print(f"  {status}  {tr.test_id}{timing}{row_info}")
+
+    if not tr.passed or verbose:
+        for check in tr.checks:
+            check_icon = "    \033[32m+\033[0m" if check.passed else "    \033[31m-\033[0m"
+            print(f"{check_icon} {check.check_name}: {check.detail}")
+        if tr.sql and (not tr.passed or verbose):
+            # Show first 200 chars of SQL for failed tests
+            sql_preview = tr.sql[:200] + ("..." if len(tr.sql) > 200 else "")
+            print(f"    SQL: {sql_preview}")
+        if tr.error:
+            print(f"    Error: {tr.error}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the natural language SQL query system"
+    )
+    parser.add_argument(
+        "--tag",
+        help="Only run test cases with this tag",
+    )
+    parser.add_argument(
+        "--id",
+        help="Only run the test case with this ID",
+    )
+    parser.add_argument(
+        "--unit",
+        action="store_true",
+        help="Only run unit tests (SQL extraction, no API calls)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which tests would run without executing them",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show details for passing tests too",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=API_CALL_DELAY_SECONDS,
+        help=f"Seconds between API calls (default: {API_CALL_DELAY_SECONDS})",
+    )
+    args = parser.parse_args()
+
+    # Load fixtures
+    with open(FIXTURES_PATH) as f:
+        fixtures = json.load(f)
+
+    results: list[TestResult] = []
+
+    # --- Unit tests (SQL extraction) ---
+    extraction_tests = fixtures.get("sql_extraction_tests", [])
+    if args.id:
+        extraction_tests = [t for t in extraction_tests if t["id"] == args.id]
+
+    if extraction_tests and not (args.tag and args.tag != "unit"):
+        print("\n\033[1mSQL Extraction Tests\033[0m")
+        print("=" * 60)
+        for tc in extraction_tests:
+            if args.dry_run:
+                print(f"  SKIP  {tc['id']} (dry run)")
+                continue
+            tr = run_extraction_test(tc)
+            results.append(tr)
+            print_result(tr, args.verbose)
+
+    if args.unit:
+        # Only unit tests requested — print summary and exit
+        _print_summary(results)
+        sys.exit(0 if all(r.passed for r in results) else 1)
+
+    # --- Query tests (require API) ---
+    service = NLQueryService()
+
+    query_tests = fixtures.get("test_cases", [])
+    if args.tag:
+        query_tests = [t for t in query_tests if args.tag in t.get("tags", [])]
+    if args.id:
+        query_tests = [t for t in query_tests if t["id"] == args.id]
+
+    if query_tests:
+        print(f"\n\033[1mQuery Tests ({len(query_tests)} cases)\033[0m")
+        print("=" * 60)
+        for i, tc in enumerate(query_tests):
+            if args.dry_run:
+                tags = ", ".join(tc.get("tags", []))
+                print(f"  SKIP  {tc['id']} [{tags}]: {tc['question']}")
+                continue
+
+            # Rate limiting between API calls
+            if i > 0:
+                time.sleep(args.delay)
+
+            tr = run_query_test(service, tc)
+            results.append(tr)
+            print_result(tr, args.verbose)
+
+    # --- Safety tests ---
+    safety_tests = fixtures.get("safety_tests", [])
+    if args.id:
+        safety_tests = [t for t in safety_tests if t["id"] == args.id]
+
+    if safety_tests and not args.tag:
+        print(f"\n\033[1mSafety Tests ({len(safety_tests)} cases)\033[0m")
+        print("=" * 60)
+        for i, tc in enumerate(safety_tests):
+            if args.dry_run:
+                print(f"  SKIP  {tc['id']}: {tc['question']}")
+                continue
+
+            if i > 0 or query_tests:
+                time.sleep(args.delay)
+
+            tr = run_safety_test(service, tc)
+            results.append(tr)
+            print_result(tr, args.verbose)
+
+    _print_summary(results)
+    sys.exit(0 if all(r.passed for r in results) else 1)
+
+
+def _print_summary(results: list[TestResult]) -> None:
+    """Print final summary."""
+    if not results:
+        print("\nNo tests were run.")
+        return
+
+    passed = sum(1 for r in results if r.passed)
+    failed = sum(1 for r in results if not r.passed)
+    total_time = sum(r.duration_seconds for r in results)
+
+    print()
+    print("=" * 60)
+    color = "\033[32m" if failed == 0 else "\033[31m"
+    print(
+        f"{color}{passed}/{len(results)} passed, {failed} failed\033[0m"
+        f" ({total_time:.1f}s total)"
+    )
+
+    if failed > 0:
+        print(f"\nFailed tests:")
+        for r in results:
+            if not r.passed:
+                failed_names = [c.check_name for c in r.failed_checks]
+                print(f"  - {r.test_id}: {', '.join(failed_names)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_nl_query.py
+++ b/scripts/eval_nl_query.py
@@ -13,6 +13,8 @@ Usage:
     uv run python scripts/eval_nl_query.py --dry-run         # Show what would run
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
@@ -21,17 +23,10 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-# Add project root to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from tournament_visualizer.data.nl_query import (
-    NLQueryService,
-    QueryResult,
-    _extract_sql,
-    _validate_sql,
-)
+if TYPE_CHECKING:
+    from tournament_visualizer.data.nl_query import NLQueryService
 
 logging.basicConfig(
     level=logging.WARNING,
@@ -326,6 +321,8 @@ def run_safety_test(
     elif test_case.get("expect_success_or_safe_sql"):
         # LLM might generate a harmless SELECT or might refuse — both are OK
         if result.success:
+            from tournament_visualizer.data.nl_query import _validate_sql
+
             # If it succeeded, verify the SQL is a safe SELECT (no DML)
             validation = _validate_sql(result.sql) if result.sql else None
             check = CheckResult(
@@ -347,6 +344,8 @@ def run_safety_test(
 
 def run_extraction_test(test_case: dict) -> TestResult:
     """Run a SQL extraction unit test (no API call)."""
+    from tournament_visualizer.data.nl_query import _extract_sql
+
     test_id = test_case["id"]
     input_text = test_case["input"]
     expected = test_case["expected_sql"]
@@ -394,6 +393,9 @@ def print_result(tr: TestResult, verbose: bool = False) -> None:
 
 
 def main() -> None:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from tournament_visualizer.data.nl_query import NLQueryService
+
     parser = argparse.ArgumentParser(
         description="Evaluate the natural language SQL query system"
     )

--- a/tests/test_parser_territories.py
+++ b/tests/test_parser_territories.py
@@ -39,7 +39,9 @@ def test_extract_territories_basic_structure(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=2)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=2, player_id_mapping={}
+    )
 
     # Should have 3 tiles × 2 turns = 6 records
     assert len(territories) == 6
@@ -60,7 +62,9 @@ def test_extract_territories_coordinates(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     # Map width is 3, so:
     # Tile 0: x=0, y=0
@@ -83,9 +87,11 @@ def test_extract_territories_ownership(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=2)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=2, player_id_mapping={}
+    )
 
-    # Without player_id_mapping, slot IDs are stored as-is (1-based from XML 0-based)
+    # With empty mapping, slot IDs are stored as-is (1-based from XML 0-based)
     # Tile 0, turn 1: owned by player 0 (XML) -> slot 1
     tile0_turn1 = [
         t for t in territories if t["tile_id"] == 0 and t["turn_number"] == 1
@@ -140,7 +146,9 @@ def test_extract_territories_terrain(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     # Check terrain for each tile (turn 1)
     terrains = {
@@ -159,7 +167,9 @@ def test_extract_territories_all_turns(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=2)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=2, player_id_mapping={}
+    )
 
     # Group by tile and turn
     tiles_by_turn = {}
@@ -184,7 +194,9 @@ def test_extract_territories_ownership_persistence(minimal_xml_tree):
     parser = OldWorldSaveParser("")
     parser.root = minimal_xml_tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=2)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=2, player_id_mapping={}
+    )
 
     # Tile 2: owned by player 1 at turn 1, no entry for turn 2
     # Should persist ownership to turn 2
@@ -210,7 +222,9 @@ def test_extract_territories_empty_xml():
     parser = OldWorldSaveParser("")
     parser.root = tree.getroot()
 
-    territories = parser.extract_territories(match_id=1, final_turn=10)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=10, player_id_mapping={}
+    )
 
     # Should return empty list, not error
     assert territories == []
@@ -231,7 +245,9 @@ def test_extract_territories_no_map_width():
     parser.root = tree.getroot()
 
     with pytest.raises(ValueError, match="MapWidth"):
-        parser.extract_territories(match_id=1, final_turn=1)
+        parser.extract_territories(
+            match_id=1, final_turn=1, player_id_mapping={}
+        )
 
 
 def test_extract_territories_includes_specialists() -> None:
@@ -251,7 +267,9 @@ def test_extract_territories_includes_specialists() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     # Find the tile record
     tile_record = next(t for t in territories if t["tile_id"] == 0)
@@ -277,7 +295,9 @@ def test_extract_territories_includes_improvements() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     tile_record = next(t for t in territories if t["tile_id"] == 5)
 
@@ -300,7 +320,9 @@ def test_extract_territories_includes_resources() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     tile_record = next(t for t in territories if t["tile_id"] == 7)
 
@@ -323,7 +345,9 @@ def test_extract_territories_includes_roads() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     tile_record = next(t for t in territories if t["tile_id"] == 3)
 
@@ -344,7 +368,9 @@ def test_extract_territories_defaults_to_none_when_missing() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     tile_record = next(t for t in territories if t["tile_id"] == 10)
 
@@ -373,7 +399,9 @@ def test_extract_territories_combines_all_attributes() -> None:
     parser = OldWorldSaveParser("")
     parser.root = ET.fromstring(xml_content)
 
-    territories = parser.extract_territories(match_id=1, final_turn=1)
+    territories = parser.extract_territories(
+        match_id=1, final_turn=1, player_id_mapping={}
+    )
 
     tile_record = next(t for t in territories if t["tile_id"] == 15)
 

--- a/tournament_visualizer/app.py
+++ b/tournament_visualizer/app.py
@@ -213,6 +213,13 @@ app.layout = dbc.Container(
                                 active="exact",
                             )
                         ),
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                [html.I(className="bi bi-chat-dots me-2"), "Chat"],
+                                href="/chat",
+                                active="exact",
+                            )
+                        ),
                     ],
                     className="me-auto",
                     navbar=True,

--- a/tournament_visualizer/app.py
+++ b/tournament_visualizer/app.py
@@ -135,6 +135,14 @@ app.index_string = """<!DOCTYPE html>
             .dbc .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner th.dash-filter input::placeholder {
                 color: #c8d4e3 !important;
             }
+            /* Chat input - remove focus glow and placeholder on focus */
+            #chat-input:focus {
+                box-shadow: none !important;
+                outline: none !important;
+            }
+            #chat-input:focus::placeholder {
+                color: transparent !important;
+            }
             /* DataTable sort indicators - match header text color */
             .dash-table-container .column-header--sort {
                 color: #edf2f7 !important;

--- a/tournament_visualizer/assets/style.css
+++ b/tournament_visualizer/assets/style.css
@@ -65,6 +65,7 @@ body {
     background-color: #26405e !important;
     color: #edf2f7 !important;
     line-height: 1.6;
+    min-height: 100vh;
 }
 
 /* Navbar customizations */

--- a/tournament_visualizer/config.py
+++ b/tournament_visualizer/config.py
@@ -57,7 +57,7 @@ class Config:
 
     # Groq API configuration (for natural language SQL queries)
     GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
-    GROQ_MODEL = os.getenv("GROQ_MODEL", "qwen/qwen3-32b")
+    GROQ_MODEL = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
     NL_QUERY_ROW_LIMIT = 200
 
     # UI Configuration

--- a/tournament_visualizer/config.py
+++ b/tournament_visualizer/config.py
@@ -55,6 +55,11 @@ class Config:
     # Anthropic API configuration (for match narrative generation)
     ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 
+    # Groq API configuration (for natural language SQL queries)
+    GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
+    GROQ_MODEL = os.getenv("GROQ_MODEL", "qwen/qwen3-32b")
+    NL_QUERY_ROW_LIMIT = 200
+
     # UI Configuration
     DEFAULT_PAGE_SIZE = 25
     MAX_CHART_POINTS = 1000

--- a/tournament_visualizer/data/etl.py
+++ b/tournament_visualizer/data/etl.py
@@ -280,11 +280,10 @@ class TournamentETL:
             parser = OldWorldSaveParser(file_path)
             parser.extract_and_parse()
             territories = parser.extract_territories(
-                match_id=match_id, final_turn=final_turn
+                match_id=match_id,
+                final_turn=final_turn,
+                player_id_mapping=player_id_mapping,
             )
-
-            # Note: owner_player_id is already in database format (1-based) from parser
-            # No need to remap player IDs as parser handles the conversion
 
             if territories:
                 self.db.bulk_insert_territories(territories)

--- a/tournament_visualizer/data/groq_client.py
+++ b/tournament_visualizer/data/groq_client.py
@@ -67,7 +67,7 @@ class GroqClient:
     def generate(
         self,
         messages: list[dict[str, str]],
-        model: str = "qwen/qwen3-32b",
+        model: str = "llama-3.3-70b-versatile",
         max_tokens: int = 2048,
         temperature: float = 0.0,
     ) -> GroqResponse:

--- a/tournament_visualizer/data/groq_client.py
+++ b/tournament_visualizer/data/groq_client.py
@@ -1,0 +1,158 @@
+"""Groq API client for natural language SQL query generation.
+
+Mirrors the AnthropicClient pattern: lazy client init, exponential backoff
+retry for transient errors, and clear error classification.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+
+import groq
+from groq import Groq
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GroqResponse:
+    """Structured response from Groq API."""
+
+    content: str
+    model: str
+    usage_prompt_tokens: int
+    usage_completion_tokens: int
+
+
+class GroqClient:
+    """Client for Groq API with retry logic.
+
+    Attributes:
+        api_key: Groq API key
+        max_retries: Maximum retry attempts
+        initial_retry_delay: Initial backoff delay in seconds
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        max_retries: int = 2,
+        initial_retry_delay: float = 2.0,
+    ) -> None:
+        """Initialize Groq client.
+
+        Args:
+            api_key: Groq API key
+            max_retries: Maximum retry attempts
+            initial_retry_delay: Initial backoff delay in seconds
+
+        Raises:
+            ValueError: If api_key is empty
+        """
+        if not api_key:
+            raise ValueError("Groq API key is required")
+
+        self.api_key = api_key
+        self.max_retries = max_retries
+        self.initial_retry_delay = initial_retry_delay
+        self._client: Groq | None = None
+
+    @property
+    def client(self) -> Groq:
+        """Lazy-initialize Groq client."""
+        if self._client is None:
+            self._client = Groq(api_key=self.api_key)
+        return self._client
+
+    def generate(
+        self,
+        messages: list[dict[str, str]],
+        model: str = "qwen/qwen3-32b",
+        max_tokens: int = 2048,
+        temperature: float = 0.0,
+    ) -> GroqResponse:
+        """Generate a chat completion with retry logic.
+
+        Args:
+            messages: List of {"role": ..., "content": ...} dicts
+            model: Model identifier
+            max_tokens: Max tokens to generate
+            temperature: Sampling temperature (0.0 for deterministic SQL)
+
+        Returns:
+            GroqResponse with content and usage info
+
+        Raises:
+            groq.RateLimitError: After all retries exhausted on 429
+            groq.AuthenticationError: Immediately on 401 (no retry)
+            groq.APIError: On persistent server errors
+        """
+        for attempt in range(self.max_retries):
+            try:
+                logger.debug(
+                    f"Calling Groq API (attempt {attempt + 1}/{self.max_retries})"
+                )
+                response = self.client.chat.completions.create(
+                    messages=messages,
+                    model=model,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+                logger.debug("Groq API call successful")
+                return GroqResponse(
+                    content=response.choices[0].message.content or "",
+                    model=response.model or model,
+                    usage_prompt_tokens=(
+                        response.usage.prompt_tokens if response.usage else 0
+                    ),
+                    usage_completion_tokens=(
+                        response.usage.completion_tokens if response.usage else 0
+                    ),
+                )
+
+            except groq.RateLimitError as e:
+                if attempt < self.max_retries - 1:
+                    delay = self.initial_retry_delay * (2**attempt)
+                    logger.warning(f"Groq rate limit, retry in {delay}s: {e}")
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        f"Groq rate limit exceeded after {self.max_retries} retries"
+                    )
+                    raise
+
+            except groq.APIConnectionError as e:
+                if attempt < self.max_retries - 1:
+                    delay = self.initial_retry_delay * (2**attempt)
+                    logger.warning(f"Groq connection error, retry in {delay}s: {e}")
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        f"Groq connection failed after {self.max_retries} retries"
+                    )
+                    raise
+
+            except (groq.AuthenticationError, groq.PermissionDeniedError):
+                # Don't retry auth errors
+                raise
+
+            except groq.APIError as e:
+                # Don't retry client errors (4xx)
+                if (
+                    hasattr(e, "status_code")
+                    and e.status_code
+                    and 400 <= e.status_code < 500
+                ):
+                    logger.error(f"Groq client error (no retry): {e}")
+                    raise
+                # Retry server errors (5xx)
+                if attempt < self.max_retries - 1:
+                    delay = self.initial_retry_delay * (2**attempt)
+                    logger.warning(f"Groq server error, retry in {delay}s: {e}")
+                    time.sleep(delay)
+                else:
+                    logger.error(f"Groq server error after {self.max_retries} retries")
+                    raise
+
+        # Should never reach here due to raises above
+        raise RuntimeError("Retry loop exited unexpectedly")

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -290,6 +290,14 @@ CREATE TABLE family_opinion_history (
 
 11. Always add `ORDER BY` for deterministic results. Limit to 200 rows unless the user requests more.
 
+12. **Game uniqueness constraints** — avoid redundant columns that count the same thing:
+   - Each match has exactly **2 players**.
+   - Each player has exactly **one civilization** per match.
+   - A player can found at most **one religion** per match (RELIGION_FOUNDED event). So COUNT(*) of religion events = COUNT(DISTINCT match_id) — don't include both.
+   - Each **wonder can only be built once** per match (e.g. only one Pyramids). So counting wonder completions = counting distinct matches with that wonder.
+   - Each player has at most **one ruler alive** at a time (succession_order tracks the sequence).
+   - When results span multiple matches, use GROUP BY to summarize (e.g., player_name, COUNT(*)) rather than returning one row per match. Keep result sets concise — only show per-match detail if the user explicitly asks for it.
+
 ## Example Queries
 
 **Civilization win rate** ("What is Carthage's win rate?"):

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -49,6 +49,13 @@ _FORBIDDEN_PATTERNS: list[str] = [
     r"\bPRAGMA\b",
     r"\bVACUUM\b",
     r"\bCALL\b",
+    # DuckDB file-system access functions (defense-in-depth)
+    r"\bREAD_CSV\b",
+    r"\bREAD_PARQUET\b",
+    r"\bREAD_JSON\b",
+    r"\bREAD_JSON_AUTO\b",
+    r"\bHTTPFS\b",
+    r"\bHTTPGET\b",
 ]
 
 _SYSTEM_PROMPT = """\

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -1,0 +1,582 @@
+"""Natural language to SQL query service.
+
+Orchestrates: system prompt construction -> Groq API call -> SQL extraction
+-> safety validation -> DuckDB execution -> DataFrame result.
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+import groq
+import pandas as pd
+
+from tournament_visualizer.config import Config
+from tournament_visualizer.data.database import TournamentDatabase, get_database
+from tournament_visualizer.data.groq_client import GroqClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QueryResult:
+    """Result of a natural language query."""
+
+    success: bool
+    df: pd.DataFrame = field(default_factory=pd.DataFrame)
+    sql: str = ""
+    error_message: str = ""
+    is_rate_limited: bool = False
+
+
+# SQL keywords that must never appear in generated queries
+_FORBIDDEN_PATTERNS: list[str] = [
+    r"\bINSERT\b",
+    r"\bUPDATE\b",
+    r"\bDELETE\b",
+    r"\bDROP\b",
+    r"\bALTER\b",
+    r"\bCREATE\b",
+    r"\bTRUNCATE\b",
+    r"\bGRANT\b",
+    r"\bREVOKE\b",
+    r"\bATTACH\b",
+    r"\bDETACH\b",
+    r"\bCOPY\b",
+    r"\bEXPORT\b",
+    r"\bIMPORT\b",
+    r"\bPRAGMA\b",
+    r"\bVACUUM\b",
+    r"\bCALL\b",
+]
+
+_SYSTEM_PROMPT = """\
+You are a SQL query generator for an Old World tournament database (DuckDB).
+Given a natural language question, respond with ONLY a single ```sql code block containing a DuckDB SELECT query.
+Do NOT include any reasoning, explanation, or commentary. No text before or after the code block.
+/no_think
+
+## Database Schema
+
+```sql
+-- 49 matches, 98 players (2 per match), ~25 tournament participants
+
+CREATE TABLE matches (
+    match_id BIGINT NOT NULL,
+    game_name VARCHAR,
+    map_size VARCHAR,                -- 'Tiny','Small','Medium','Large'
+    map_class VARCHAR,               -- 'Coastal Rain Basin','Highlands', etc.
+    total_turns INTEGER,
+    tournament_round INTEGER,        -- positive=Winners bracket, negative=Losers bracket, NULL=unknown
+    save_date TIMESTAMP
+);
+
+CREATE TABLE match_metadata (
+    match_id BIGINT NOT NULL,
+    difficulty VARCHAR,
+    victory_type VARCHAR,
+    victory_turn INTEGER
+);
+
+-- IMPORTANT: Always use this for winner queries. NEVER use matches.winner_player_id (often NULL).
+CREATE TABLE match_winners (
+    match_id BIGINT NOT NULL,
+    winner_player_id BIGINT NOT NULL  -- References players.player_id
+);
+
+-- Pre-joined convenience view
+CREATE TABLE match_summary (
+    match_id BIGINT,
+    game_name VARCHAR,
+    total_turns INTEGER,
+    map_size VARCHAR,
+    winner_name VARCHAR,
+    winner_civilization VARCHAR
+);
+
+CREATE TABLE players (
+    player_id BIGINT NOT NULL,       -- Global unique ID across all matches
+    match_id BIGINT NOT NULL,
+    player_name VARCHAR NOT NULL,
+    player_name_normalized VARCHAR NOT NULL,
+    civilization VARCHAR,            -- 'Aksum','Assyria','Babylonia','Carthage','Egypt','Greece','Hittite','Kush','Persia','Rome'
+    final_score INTEGER DEFAULT 0,
+    is_human BOOLEAN DEFAULT TRUE,
+    participant_id BIGINT            -- Links to tournament_participants (may be NULL)
+);
+
+CREATE TABLE tournament_participants (
+    participant_id BIGINT NOT NULL,
+    display_name VARCHAR NOT NULL,    -- Canonical name for this person across all matches
+    display_name_normalized VARCHAR NOT NULL,
+    seed INTEGER,
+    final_rank INTEGER
+);
+
+-- Per-turn yield RATE (production per turn). NOT cumulative. Amount at 10x scale.
+CREATE TABLE player_yield_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    resource_type VARCHAR NOT NULL,  -- 'YIELD_SCIENCE','YIELD_CIVICS','YIELD_TRAINING','YIELD_CULTURE','YIELD_MONEY','YIELD_FOOD','YIELD_GROWTH','YIELD_ORDERS','YIELD_HAPPINESS','YIELD_DISCONTENT','YIELD_IRON','YIELD_STONE','YIELD_WOOD','YIELD_MAINTENANCE'
+    amount INTEGER NOT NULL          -- Rate per turn at 10x scale. Divide by 10.0 for display (e.g. 215 -> 21.5/turn)
+);
+
+-- Cumulative yield totals over time. Amount at 10x scale.
+CREATE TABLE player_yield_total_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    resource_type VARCHAR NOT NULL,
+    amount INTEGER NOT NULL          -- Cumulative total at 10x scale. Divide by 10.0 for display.
+);
+
+CREATE TABLE player_military_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    military_power INTEGER NOT NULL
+);
+
+CREATE TABLE player_points_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    points INTEGER NOT NULL
+);
+
+CREATE TABLE player_legitimacy_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    legitimacy INTEGER NOT NULL
+);
+
+CREATE TABLE player_statistics (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    stat_category VARCHAR NOT NULL,
+    stat_name VARCHAR NOT NULL,
+    value INTEGER NOT NULL
+);
+
+CREATE TABLE cities (
+    city_id INTEGER NOT NULL,
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,       -- Current owner
+    city_name VARCHAR NOT NULL,
+    founded_turn INTEGER NOT NULL,
+    family_name VARCHAR,             -- e.g. 'FAMILY_BARCID'. See family classes below.
+    is_capital BOOLEAN DEFAULT FALSE,
+    population INTEGER,
+    first_player_id BIGINT           -- Original founder (differs if city was captured)
+);
+
+CREATE TABLE city_projects (
+    match_id BIGINT NOT NULL,
+    city_id INTEGER NOT NULL,
+    project_type VARCHAR NOT NULL,   -- e.g. 'PROJECT_ISHTAR_GATE','PROJECT_PYRAMIDS','PROJECT_FORUM_1','PROJECT_TEMPLE_1','PROJECT_MONASTERY_1'
+    count INTEGER NOT NULL
+);
+
+CREATE TABLE city_unit_production (
+    match_id BIGINT NOT NULL,
+    city_id INTEGER NOT NULL,
+    unit_type VARCHAR NOT NULL,
+    count INTEGER NOT NULL
+);
+
+CREATE TABLE units_produced (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    unit_type VARCHAR NOT NULL,
+    count INTEGER NOT NULL
+);
+
+CREATE TABLE unit_classifications (
+    unit_type VARCHAR NOT NULL,      -- e.g. 'UNIT_SPEARMAN'
+    category VARCHAR NOT NULL,       -- 'military','civilian','religious'
+    role VARCHAR NOT NULL            -- 'infantry','ranged','cavalry','siege','naval','settler','worker','scout','religious'
+);
+
+CREATE TABLE events (
+    event_id BIGINT NOT NULL,
+    match_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    event_type VARCHAR NOT NULL,     -- e.g. 'LAW_ADOPTED','TECH_DISCOVERED','CITY_FOUNDED','WONDER_ACTIVITY'
+    player_id BIGINT,
+    description VARCHAR,
+    event_data JSON
+);
+
+CREATE TABLE technology_progress (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    tech_name VARCHAR NOT NULL,      -- e.g. 'TECH_SCHOLARSHIP','TECH_JURISPRUDENCE','TECH_POLIS'
+    count INTEGER NOT NULL
+);
+
+CREATE TABLE rulers (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    ruler_name VARCHAR,
+    archetype VARCHAR,               -- e.g. 'ARCHETYPE_TACTICIAN','ARCHETYPE_SCHOLAR','ARCHETYPE_DIPLOMAT'
+    cognomen VARCHAR,                -- e.g. 'Great','Magnificent','Lion'
+    succession_order INTEGER NOT NULL,
+    succession_turn INTEGER NOT NULL
+);
+
+-- WARNING: 8.8 million rows. ALWAYS filter by match_id AND turn_number.
+CREATE TABLE territories (
+    match_id BIGINT NOT NULL,
+    x_coordinate INTEGER NOT NULL,
+    y_coordinate INTEGER NOT NULL,
+    turn_number INTEGER NOT NULL,
+    terrain_type VARCHAR,
+    improvement_type VARCHAR,        -- e.g. 'IMPROVEMENT_MINE','IMPROVEMENT_FARM','IMPROVEMENT_QUARRY'
+    specialist_type VARCHAR,         -- e.g. 'SPECIALIST_FARMER','SPECIALIST_PHILOSOPHER_2'
+    resource_type VARCHAR,           -- e.g. 'RESOURCE_IRON','RESOURCE_HORSE','RESOURCE_MARBLE'
+    has_road BOOLEAN DEFAULT FALSE,
+    owner_player_id BIGINT,
+    city_id INTEGER
+);
+
+CREATE TABLE family_opinion_history (
+    match_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    turn_number INTEGER NOT NULL,
+    family_name VARCHAR NOT NULL,
+    opinion INTEGER NOT NULL
+);
+```
+
+## Critical Rules
+
+1. **Winners**: ALWAYS use `match_winners` joined to `players`. NEVER use `matches.winner_player_id`.
+   Pattern: `FROM match_winners mw JOIN players p ON mw.match_id = p.match_id AND mw.winner_player_id = p.player_id`
+
+2. **Yield data**: `player_yield_history` stores the **production rate per turn** (e.g. science/turn on turn 50). It is NOT a cumulative total.
+   - `amount` is stored at 10x scale. Always use `amount / 10.0` for display.
+   - NEVER apply AVG() or SUM() directly to per-turn `amount` values across all turns — averaging hundreds of turns is meaningless.
+   - For cross-match comparisons: first get per-match peaks via a subquery (`MAX(amount / 10.0) GROUP BY match_id, player_id`), then aggregate across matches with AVG/MAX.
+   - `player_yield_total_history` stores cumulative totals if needed.
+
+3. **territories table**: 8.8M rows. ALWAYS filter by `match_id` AND `turn_number`. For end-state: `turn_number = (SELECT MAX(turn_number) FROM territories WHERE match_id = t.match_id)`.
+
+4. **player_id** is a global unique ID, NOT a per-match slot number. Always join on both `match_id` AND `player_id`.
+
+5. **DuckDB SQL**: Use `STRING_AGG(col, ', ')` not GROUP_CONCAT. Use `ILIKE` for case-insensitive matching. CTEs and window functions are supported.
+
+6. **Naming conventions**:
+   - Families: `FAMILY_BARCID`, `FAMILY_JULIUS`, etc.
+   - Techs: `TECH_SCHOLARSHIP`, `TECH_JURISPRUDENCE`, etc.
+   - Units: `UNIT_SPEARMAN`, `UNIT_ARCHER`, `UNIT_SETTLER`, etc.
+   - Yields: `YIELD_SCIENCE`, `YIELD_FOOD`, `YIELD_MONEY`, etc.
+   - Use ILIKE with wildcards when the user uses partial names (e.g. 'scholarship' -> `tech_name ILIKE '%SCHOLARSHIP%'`).
+
+7. **Wonders vs city projects**: These are DIFFERENT things.
+   - **Wonders** (Ishtar Gate, Pyramids, Hanging Gardens, etc.) are tracked in `events` with `event_type = 'WONDER_ACTIVITY'`. Filter `description ILIKE '%completed%'` for built wonders. The wonder name and builder are in the description text (e.g. "The Pyramids completed by  Egypt (Jams)!").
+   - **City projects** (`city_projects` table) are city improvements like FORUM, ARCHIVE, TREASURY, WALLS, TEMPLE, MONASTERY, FESTIVAL, HUNT, etc. These are NOT wonders.
+
+8. **Column naming**: Use clear, unambiguous column names. Say `matches_played` not `matches`. Say `matches_with_wonders` if counting only matches where a condition was met.
+
+9. **Family classes** (family_name -> class): Champions (SARGONID,ARGEAD,FABIUS,AKSUM_AGAW), Riders (BARCID,RAMESSIDE,ARSACID,KUSSARAN), Hunters (TUDIYA,KASSITE,MIHRANID,YAM), Artisans (MAGONID,CHALDEAN,CYPSELID,IRTJET), Traders (HANNONID,ISIN,HATTUSAN,AKSUM_AGAZI,WAWAT), Sages (AMORITE,THUTMOSID,ALCMAEONID), Statesmen (DIDONIAN,ACHAEMENID,JULIUS), Patrons (ADASI,SELEUCID,VALERIUS,ZALPUWAN,AKSUM_BARYA), Clerics (ERISHUM,AMARNA,SASANID,AKSUM_TIGRAYAN), Landowners (CLAUDIUS,SAITE,NENASSAN,SETJU).
+
+10. **Identifying people across matches**: Players use different in-game names across matches. Use `COALESCE(tp.display_name, p.player_name)` with `LEFT JOIN tournament_participants tp ON p.participant_id = tp.participant_id` to get canonical names.
+   - Group by `COALESCE(tp.display_name, p.player_name)` for cross-match aggregation.
+   - For total match counts, compute from the full `players` table — NEVER from a filtered subquery (that only counts matches in the filtered dataset). Use a separate subquery or CTE if needed.
+
+11. Always add `ORDER BY` for deterministic results. Limit to 200 rows unless the user requests more.
+
+## Example Queries
+
+**Civilization win rate** ("What is Carthage's win rate?"):
+Win rate = wins / total matches played as that civilization. Each match has 2 players.
+```sql
+SELECT
+    p.civilization,
+    COUNT(*) AS matches_played,
+    COUNT(mw.winner_player_id) AS wins,
+    ROUND(COUNT(mw.winner_player_id) * 100.0 / COUNT(*), 1) AS win_rate
+FROM players p
+LEFT JOIN match_winners mw
+    ON p.match_id = mw.match_id AND p.player_id = mw.winner_player_id
+WHERE p.civilization ILIKE '%Carthage%'
+GROUP BY p.civilization
+ORDER BY win_rate DESC;
+```
+
+**Who built the most wonders** ("Who built the most wonders?"):
+Wonders are in events table, not city_projects. Filter completed wonders.
+```sql
+SELECT
+    COALESCE(tp.display_name, p.player_name) AS player,
+    COUNT(*) AS wonders_built,
+    COUNT(DISTINCT e.match_id) AS matches_with_wonders
+FROM events e
+JOIN players p ON e.match_id = p.match_id AND e.player_id = p.player_id
+LEFT JOIN tournament_participants tp ON p.participant_id = tp.participant_id
+WHERE e.event_type = 'WONDER_ACTIVITY'
+    AND e.description ILIKE '%completed%'
+GROUP BY COALESCE(tp.display_name, p.player_name)
+ORDER BY wonders_built DESC
+LIMIT 20;
+```
+
+**Who built the most city projects** ("Who built the most temples?"):
+City projects (forums, temples, monasteries, etc.) are in city_projects table.
+```sql
+SELECT
+    COALESCE(tp.display_name, p.player_name) AS player,
+    SUM(cp.count) AS total_temples,
+    COUNT(DISTINCT p.match_id) AS matches_played
+FROM city_projects cp
+JOIN cities c ON cp.match_id = c.match_id AND cp.city_id = c.city_id
+JOIN players p ON c.match_id = p.match_id AND c.player_id = p.player_id
+LEFT JOIN tournament_participants tp ON p.participant_id = tp.participant_id
+WHERE cp.project_type ILIKE '%TEMPLE%'
+GROUP BY COALESCE(tp.display_name, p.player_name)
+ORDER BY total_temples DESC
+LIMIT 20;
+```
+
+**Highest yield rate across all matches** ("Who had the highest science rate?"):
+Do NOT apply AVG or SUM directly to per-turn `amount` values — that averages hundreds of turns and is meaningless.
+Instead, first get per-match peaks via a subquery, then aggregate across matches.
+Group by player only (not by civ or match) for cross-match aggregation.
+```sql
+SELECT
+    COALESCE(tp.display_name, p.player_name) AS player,
+    COUNT(DISTINCT p.match_id) AS matches_played,
+    ROUND(MAX(match_peaks.peak_science), 1) AS best_peak_science,
+    ROUND(AVG(match_peaks.peak_science), 1) AS avg_peak_science
+FROM (
+    SELECT yh.match_id, yh.player_id, MAX(yh.amount / 10.0) AS peak_science
+    FROM player_yield_history yh
+    WHERE yh.resource_type = 'YIELD_SCIENCE'
+    GROUP BY yh.match_id, yh.player_id
+) match_peaks
+JOIN players p ON match_peaks.match_id = p.match_id AND match_peaks.player_id = p.player_id
+LEFT JOIN tournament_participants tp ON p.participant_id = tp.participant_id
+GROUP BY COALESCE(tp.display_name, p.player_name)
+ORDER BY best_peak_science DESC
+LIMIT 20;
+```
+When the user says "across all matches", group ONLY by player name — do NOT include civilization or game_name in GROUP BY.
+
+**Cross-match player comparison** ("Which players researched tech X?"):
+```sql
+SELECT
+    COALESCE(tp.display_name, p.player_name) AS player,
+    p.civilization,
+    m.game_name
+FROM technology_progress tech
+JOIN players p ON tech.match_id = p.match_id AND tech.player_id = p.player_id
+JOIN matches m ON p.match_id = m.match_id
+LEFT JOIN tournament_participants tp ON p.participant_id = tp.participant_id
+WHERE tech.tech_name ILIKE '%SCHOLARSHIP%'
+ORDER BY player;
+```
+"""
+
+
+def _extract_sql(response_text: str) -> Optional[str]:
+    """Extract SQL from LLM response text.
+
+    Handles ```sql blocks, generic code blocks, bare SQL,
+    and Qwen3's <think>...</think> preamble.
+    """
+    # Strip Qwen3 thinking blocks
+    cleaned = re.sub(r"<think>.*?</think>", "", response_text, flags=re.DOTALL).strip()
+
+    # Try markdown SQL block (preferred — most reliable)
+    match = re.search(r"```sql\s*\n?(.*?)```", cleaned, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+
+    # Try generic code block
+    match = re.search(r"```\s*\n?(.*?)```", cleaned, re.DOTALL)
+    if match:
+        candidate = match.group(1).strip()
+        if candidate.upper().startswith(("SELECT", "WITH")):
+            return candidate
+
+    # Try bare WITH ... AS (SQL CTE — must check before bare SELECT to avoid
+    # matching the inner SELECT of a CTE). Requires "AS" to distinguish from
+    # English sentences like "with the cities table..."
+    match = re.search(r"(WITH\s+\w+\s+AS\b.+)", cleaned, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip().rstrip(";")
+
+    # Try bare SELECT (unambiguous)
+    match = re.search(r"(SELECT\b.+)", cleaned, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip().rstrip(";")
+
+    return None
+
+
+def _validate_sql(sql: str) -> Optional[str]:
+    """Validate SQL is safe to execute.
+
+    Returns None if valid, or an error message if unsafe.
+    """
+    sql_upper = sql.upper()
+
+    if not sql_upper.lstrip().startswith(("SELECT", "WITH")):
+        return "Only SELECT queries are allowed."
+
+    for pattern in _FORBIDDEN_PATTERNS:
+        if re.search(pattern, sql_upper):
+            keyword = pattern.replace(r"\b", "")
+            return f"Query contains forbidden keyword: {keyword}"
+
+    # Reject multiple statements
+    if re.search(r";\s*\S", sql):
+        return "Multiple statements are not allowed."
+
+    return None
+
+
+class NLQueryService:
+    """Service for executing natural language queries against the tournament DB."""
+
+    def __init__(
+        self,
+        groq_client: Optional[GroqClient] = None,
+        database: Optional[TournamentDatabase] = None,
+    ) -> None:
+        self._groq_client = groq_client
+        self._db = database
+
+    @property
+    def groq_client(self) -> GroqClient:
+        """Lazy-init Groq client from config."""
+        if self._groq_client is None:
+            self._groq_client = GroqClient(api_key=Config.GROQ_API_KEY)
+        return self._groq_client
+
+    @property
+    def db(self) -> TournamentDatabase:
+        """Get database instance."""
+        if self._db is None:
+            self._db = get_database()
+        return self._db
+
+    def ask(self, question: str) -> QueryResult:
+        """Execute a natural language query.
+
+        Args:
+            question: User's natural language question
+
+        Returns:
+            QueryResult with success/failure, DataFrame, SQL, and error info
+        """
+        logger.info(f"Chat question: {question}")
+
+        if not Config.GROQ_API_KEY:
+            logger.warning("Chat failed: GROQ_API_KEY not configured")
+            return QueryResult(
+                success=False,
+                error_message="Groq API key not configured. Set GROQ_API_KEY in your environment.",
+            )
+
+        # Step 1: Generate SQL via LLM
+        try:
+            messages = [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": question},
+            ]
+            response = self.groq_client.generate(
+                messages=messages,
+                model=Config.GROQ_MODEL,
+            )
+            logger.info(
+                f"Groq response: model={response.model} "
+                f"tokens={response.usage_prompt_tokens}+{response.usage_completion_tokens}"
+            )
+            logger.debug(f"Groq raw response:\n{response.content}")
+        except groq.RateLimitError:
+            logger.warning("Chat failed: Groq rate limit")
+            return QueryResult(
+                success=False,
+                error_message=(
+                    "Groq API rate limit reached. The free tier allows ~30 requests/minute. "
+                    "Please wait a moment and try again."
+                ),
+                is_rate_limited=True,
+            )
+        except groq.AuthenticationError:
+            logger.error("Chat failed: Groq authentication error")
+            return QueryResult(
+                success=False,
+                error_message="Groq API authentication failed. Check your GROQ_API_KEY.",
+            )
+        except Exception as e:
+            logger.error(f"Chat failed: Groq API error: {e}")
+            return QueryResult(
+                success=False,
+                error_message=f"Error calling Groq API: {type(e).__name__}",
+            )
+
+        # Step 2: Extract SQL
+        sql = _extract_sql(response.content)
+        if sql is None:
+            logger.warning(f"Chat failed: could not extract SQL from response:\n{response.content}")
+            return QueryResult(
+                success=False,
+                sql=response.content,
+                error_message="Could not extract a SQL query from the AI response. Try rephrasing your question.",
+            )
+
+        logger.info(f"Generated SQL:\n{sql}")
+
+        # Step 3: Validate safety
+        validation_error = _validate_sql(sql)
+        if validation_error:
+            logger.warning(f"Chat failed: SQL validation: {validation_error}")
+            return QueryResult(
+                success=False,
+                sql=sql,
+                error_message=f"Safety check failed: {validation_error}",
+            )
+
+        # Step 4: Execute
+        try:
+            with self.db.get_connection() as conn:
+                df = conn.execute(sql).df()
+
+            logger.info(f"Query returned {len(df)} rows, {len(df.columns)} columns")
+
+            row_limit = Config.NL_QUERY_ROW_LIMIT
+            if len(df) > row_limit:
+                df = df.head(row_limit)
+                logger.info(f"Results truncated to {row_limit} rows")
+                return QueryResult(
+                    success=True,
+                    df=df,
+                    sql=sql,
+                    error_message=f"Results truncated to {row_limit} rows.",
+                )
+
+            return QueryResult(success=True, df=df, sql=sql)
+
+        except Exception as e:
+            logger.warning(f"Chat failed: SQL execution error: {e}\nSQL: {sql}")
+            return QueryResult(
+                success=False,
+                sql=sql,
+                error_message=f"SQL execution error: {e}",
+            )
+
+
+_service: Optional[NLQueryService] = None
+
+
+def get_nl_query_service() -> NLQueryService:
+    """Get the global NLQueryService singleton."""
+    global _service
+    if _service is None:
+        _service = NLQueryService()
+    return _service

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -275,9 +275,10 @@ CREATE TABLE family_opinion_history (
    - Yields: `YIELD_SCIENCE`, `YIELD_FOOD`, `YIELD_MONEY`, etc.
    - Use ILIKE with wildcards when the user uses partial names (e.g. 'scholarship' -> `tech_name ILIKE '%SCHOLARSHIP%'`).
 
-7. **Wonders vs city projects**: These are DIFFERENT things.
+7. **Wonders vs city projects vs tile improvements**: These are THREE DIFFERENT things.
    - **Wonders** (Ishtar Gate, Pyramids, Hanging Gardens, etc.) are tracked in `events` with `event_type = 'WONDER_ACTIVITY'`. Filter `description ILIKE '%completed%'` for built wonders. The wonder name and builder are in the description text (e.g. "The Pyramids completed by  Egypt (Jams)!").
-   - **City projects** (`city_projects` table) are city improvements like FORUM, ARCHIVE, TREASURY, WALLS, TEMPLE, MONASTERY, FESTIVAL, HUNT, etc. These are NOT wonders.
+   - **City projects** (`city_projects` table) are administrative projects: FORUM, ARCHIVE, TREASURY, WALLS, TEMPLE, MONASTERY, FESTIVAL, HUNT, etc. These are NOT wonders and NOT tile improvements.
+   - **Tile improvements** (barracks, mines, farms, quarries, ranges, garrisons, lumbermills, camps, nets, granaries, forts, theaters, groves, courts, harbors, etc.) are in the `territories` table as `improvement_type` (e.g. `IMPROVEMENT_BARRACKS`, `IMPROVEMENT_MINE`). Count at end-of-game: filter `turn_number = (SELECT MAX(turn_number) FROM territories WHERE match_id = t.match_id)` and `improvement_type ILIKE '%BARRACKS%'`.
 
 8. **Column naming**: Use clear, unambiguous column names. Say `matches_played` not `matches`. Say `matches_with_wonders` if counting only matches where a condition was met.
 

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -263,6 +263,7 @@ CREATE TABLE family_opinion_history (
    - `player_yield_total_history` stores cumulative totals if needed.
 
 3. **territories table**: 8.8M rows. ALWAYS filter by `match_id` AND `turn_number`. For end-state: `turn_number = (SELECT MAX(turn_number) FROM territories WHERE match_id = t.match_id)`.
+   Join to players via `owner_player_id`: `JOIN players p ON t.match_id = p.match_id AND t.owner_player_id = p.player_id`.
 
 4. **player_id** is a global unique ID, NOT a per-match slot number. Always join on both `match_id` AND `player_id`.
 

--- a/tournament_visualizer/data/nl_query.py
+++ b/tournament_visualizer/data/nl_query.py
@@ -435,12 +435,12 @@ def _extract_sql(response_text: str) -> Optional[str]:
     # Try markdown SQL block (preferred — most reliable)
     match = re.search(r"```sql\s*\n?(.*?)```", cleaned, re.DOTALL | re.IGNORECASE)
     if match:
-        return match.group(1).strip()
+        return match.group(1).strip().rstrip(";")
 
     # Try generic code block
     match = re.search(r"```\s*\n?(.*?)```", cleaned, re.DOTALL)
     if match:
-        candidate = match.group(1).strip()
+        candidate = match.group(1).strip().rstrip(";")
         if candidate.upper().startswith(("SELECT", "WITH")):
             return candidate
 

--- a/tournament_visualizer/data/parser.py
+++ b/tournament_visualizer/data/parser.py
@@ -814,7 +814,10 @@ class OldWorldSaveParser:
         return formatted
 
     def extract_territories(
-        self, match_id: int, final_turn: int
+        self,
+        match_id: int,
+        final_turn: int,
+        player_id_mapping: Optional[Dict[int, int]] = None,
     ) -> List[Dict[str, Any]]:
         """Extract territory control information for all tiles across all turns.
 
@@ -825,6 +828,9 @@ class OldWorldSaveParser:
         Args:
             match_id: Database match ID for foreign key reference
             final_turn: Last turn of the game (from game state data)
+            player_id_mapping: Maps 1-based slot IDs to global player_ids.
+                e.g. {1: 5, 2: 6} means slot 1 -> player_id 5.
+                If None, slot IDs are stored as-is (only correct for match 1).
 
         Returns:
             List of territory records, each containing:
@@ -838,7 +844,7 @@ class OldWorldSaveParser:
             - specialist_type: Specialist constant or None
             - resource_type: Resource constant or None
             - has_road: Boolean, True if tile has road
-            - owner_player_id: Database player ID (1-based), or None if unowned
+            - owner_player_id: Global player_id from players table, or None if unowned
 
         Raises:
             ValueError: If XML not parsed or MapWidth attribute missing
@@ -909,13 +915,16 @@ class OldWorldSaveParser:
                     turn_num = int(turn_elem.tag[1:])  # Strip 'T' prefix
                     owner_xml_id = int(turn_elem.text)
 
-                    # Convert XML player ID to database player ID
-                    # XML uses 0-based, DB uses 1-based
-                    # XML -1 = unowned/neutral -> None in DB
+                    # Convert XML player ID to global database player_id
+                    # XML uses 0-based IDs, -1 = unowned/neutral
                     if owner_xml_id == -1:
                         owner_db_id = None
                     else:
-                        owner_db_id = owner_xml_id + 1
+                        slot_id = owner_xml_id + 1
+                        if player_id_mapping:
+                            owner_db_id = player_id_mapping.get(slot_id, slot_id)
+                        else:
+                            owner_db_id = slot_id
 
                     ownership_by_turn[turn_num] = owner_db_id
 

--- a/tournament_visualizer/data/parser.py
+++ b/tournament_visualizer/data/parser.py
@@ -817,7 +817,7 @@ class OldWorldSaveParser:
         self,
         match_id: int,
         final_turn: int,
-        player_id_mapping: Optional[Dict[int, int]] = None,
+        player_id_mapping: Dict[int, int],
     ) -> List[Dict[str, Any]]:
         """Extract territory control information for all tiles across all turns.
 
@@ -830,7 +830,7 @@ class OldWorldSaveParser:
             final_turn: Last turn of the game (from game state data)
             player_id_mapping: Maps 1-based slot IDs to global player_ids.
                 e.g. {1: 5, 2: 6} means slot 1 -> player_id 5.
-                If None, slot IDs are stored as-is (only correct for match 1).
+                Pass empty dict {} if slot IDs should be stored as-is.
 
         Returns:
             List of territory records, each containing:
@@ -921,10 +921,7 @@ class OldWorldSaveParser:
                         owner_db_id = None
                     else:
                         slot_id = owner_xml_id + 1
-                        if player_id_mapping:
-                            owner_db_id = player_id_mapping.get(slot_id, slot_id)
-                        else:
-                            owner_db_id = slot_id
+                        owner_db_id = player_id_mapping.get(slot_id, slot_id)
 
                     ownership_by_turn[turn_num] = owner_db_id
 

--- a/tournament_visualizer/pages/chat.py
+++ b/tournament_visualizer/pages/chat.py
@@ -12,6 +12,7 @@ import dash_bootstrap_components as dbc
 from dash import ALL, Input, Output, State, callback, ctx, dash_table, dcc, html
 
 from tournament_visualizer.components.layouts import create_empty_state
+from tournament_visualizer.config import get_config
 from tournament_visualizer.theme import DARK_THEME
 
 logger = logging.getLogger(__name__)
@@ -211,8 +212,8 @@ def handle_chat_query(
             )
         )
 
-    # Collapsible SQL display
-    if result.sql:
+    # Collapsible SQL display (dev only)
+    if result.sql and get_config().DEBUG_MODE:
         children.append(
             html.Details(
                 [

--- a/tournament_visualizer/pages/chat.py
+++ b/tournament_visualizer/pages/chat.py
@@ -24,7 +24,7 @@ _EXAMPLE_QUESTIONS = [
     "Which players researched both Scholarship and Jurisprudence?",
     "What are the most popular civilizations?",
     "Who had the highest science yield at turn 50?",
-    "Which matches had the most units killed in a single turn?",
+    "Which matches had the biggest drop in military power?",
 ]
 
 layout = html.Div(
@@ -32,14 +32,7 @@ layout = html.Div(
         # Page header
         html.Div(
             [
-                html.H2(
-                    [html.I(className="bi bi-chat-dots me-2"), "Chat"],
-                    className="mb-1",
-                ),
-                html.P(
-                    "Ask questions about tournament data in plain English.",
-                    className="text-muted mb-3",
-                ),
+                html.H2("Chat", className="mb-3"),
             ],
             className="px-4 pt-4",
         ),
@@ -52,7 +45,6 @@ layout = html.Div(
                             id="chat-input",
                             type="text",
                             placeholder="e.g., What is Carthage's win rate?",
-                            debounce=True,
                             autoFocus=True,
                         ),
                         dbc.Button(
@@ -144,7 +136,13 @@ def handle_chat_query(
     service = get_nl_query_service()
     result = service.ask(question.strip())
 
-    children: list[Any] = []
+    children: list[Any] = [
+        html.Div(
+            [html.I(className="bi bi-chat-left-text me-2"), question.strip()],
+            className="text-muted mb-3",
+            style={"fontSize": "0.95em"},
+        ),
+    ]
 
     # Error or info message
     if result.error_message:
@@ -199,7 +197,7 @@ def handle_chat_query(
                 style_data_conditional=[
                     {
                         "if": {"row_index": "odd"},
-                        "backgroundColor": "#2d4460",
+                        "backgroundColor": DARK_THEME["bg_medium"],
                     },
                 ],
             )

--- a/tournament_visualizer/pages/chat.py
+++ b/tournament_visualizer/pages/chat.py
@@ -1,0 +1,243 @@
+"""Chat page for natural language tournament data queries.
+
+Users type questions in plain English and get tabular results,
+powered by Groq's free tier LLM translating to DuckDB SQL.
+"""
+
+import logging
+from typing import Any, Optional
+
+import dash
+import dash_bootstrap_components as dbc
+from dash import ALL, Input, Output, State, callback, ctx, dash_table, dcc, html
+
+from tournament_visualizer.components.layouts import create_empty_state
+from tournament_visualizer.theme import DARK_THEME
+
+logger = logging.getLogger(__name__)
+
+dash.register_page(__name__, path="/chat", name="Chat")
+
+_EXAMPLE_QUESTIONS = [
+    "What is Carthage's win rate?",
+    "Who built the most wonders?",
+    "Which players researched both Scholarship and Jurisprudence?",
+    "What are the most popular civilizations?",
+    "Who had the highest science yield at turn 50?",
+    "Which matches had the most units killed in a single turn?",
+]
+
+layout = html.Div(
+    [
+        # Page header
+        html.Div(
+            [
+                html.H2(
+                    [html.I(className="bi bi-chat-dots me-2"), "Chat"],
+                    className="mb-1",
+                ),
+                html.P(
+                    "Ask questions about tournament data in plain English.",
+                    className="text-muted mb-3",
+                ),
+            ],
+            className="px-4 pt-4",
+        ),
+        # Input area
+        html.Div(
+            [
+                dbc.InputGroup(
+                    [
+                        dbc.Input(
+                            id="chat-input",
+                            type="text",
+                            placeholder="e.g., What is Carthage's win rate?",
+                            debounce=True,
+                            autoFocus=True,
+                        ),
+                        dbc.Button(
+                            "Ask",
+                            id="chat-submit",
+                            color="primary",
+                            n_clicks=0,
+                        ),
+                    ],
+                    className="mb-3",
+                    size="lg",
+                ),
+                # Example questions
+                html.Div(
+                    [
+                        html.Small("Try: ", className="text-muted me-2"),
+                    ]
+                    + [
+                        html.A(
+                            q,
+                            id={"type": "chat-example", "index": i},
+                            href="#",
+                            className="text-muted me-3",
+                            style={
+                                "fontSize": "0.85em",
+                                "textDecoration": "underline",
+                                "cursor": "pointer",
+                            },
+                        )
+                        for i, q in enumerate(_EXAMPLE_QUESTIONS[:3])
+                    ],
+                    className="mb-4",
+                ),
+            ],
+            className="px-4",
+        ),
+        # Results area with loading spinner
+        html.Div(
+            [
+                dcc.Loading(
+                    id="chat-loading",
+                    type="default",
+                    children=html.Div(id="chat-results"),
+                ),
+            ],
+            className="px-4 pb-4",
+        ),
+        # Hidden store to trigger query when example is clicked
+        dcc.Store(id="chat-example-trigger"),
+    ]
+)
+
+
+@callback(
+    Output("chat-input", "value"),
+    Output("chat-example-trigger", "data"),
+    Input({"type": "chat-example", "index": ALL}, "n_clicks"),
+    prevent_initial_call=True,
+)
+def fill_example_question(n_clicks: list[Optional[int]]) -> tuple[Any, Any]:
+    """Populate the input and trigger the query when an example is clicked."""
+    if not ctx.triggered_id or not any(n_clicks):
+        return dash.no_update, dash.no_update
+    index = ctx.triggered_id["index"]
+    question = _EXAMPLE_QUESTIONS[index]
+    return question, question
+
+
+@callback(
+    Output("chat-results", "children"),
+    Input("chat-submit", "n_clicks"),
+    Input("chat-input", "n_submit"),
+    Input("chat-example-trigger", "data"),
+    State("chat-input", "value"),
+    prevent_initial_call=True,
+)
+def handle_chat_query(
+    n_clicks: int,
+    n_submit: Optional[int],
+    example_trigger: Optional[str],
+    question: Optional[str],
+) -> Any:
+    """Handle natural language query submission."""
+    if not question or not question.strip():
+        return html.Div()
+
+    from tournament_visualizer.data.nl_query import get_nl_query_service
+
+    service = get_nl_query_service()
+    result = service.ask(question.strip())
+
+    children: list[Any] = []
+
+    # Error or info message
+    if result.error_message:
+        color = "warning" if result.is_rate_limited else "danger"
+        if result.success:
+            # Truncation warning
+            color = "info"
+        icon = (
+            "bi-hourglass-split"
+            if result.is_rate_limited
+            else "bi-exclamation-triangle"
+        )
+        if result.success:
+            icon = "bi-info-circle"
+        children.append(
+            dbc.Alert(
+                [html.I(className=f"bi {icon} me-2"), result.error_message],
+                color=color,
+                className="mb-3",
+            )
+        )
+
+    # Results table
+    if result.success and not result.df.empty:
+        columns = [{"name": str(col), "id": str(col)} for col in result.df.columns]
+        children.append(
+            dash_table.DataTable(
+                id="chat-results-table",
+                columns=columns,
+                data=result.df.to_dict("records"),
+                sort_action="native",
+                page_action="native",
+                page_size=20,
+                style_table={"overflowX": "auto"},
+                style_cell={
+                    "textAlign": "left",
+                    "padding": "8px 12px",
+                    "fontFamily": "inherit",
+                    "backgroundColor": DARK_THEME["bg_dark"],
+                    "color": DARK_THEME["text_primary"],
+                    "border": f"1px solid {DARK_THEME['bg_light']}",
+                    "maxWidth": "300px",
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
+                },
+                style_header={
+                    "backgroundColor": DARK_THEME["bg_medium"],
+                    "fontWeight": "bold",
+                    "color": DARK_THEME["text_primary"],
+                    "border": f"1px solid {DARK_THEME['bg_light']}",
+                },
+                style_data_conditional=[
+                    {
+                        "if": {"row_index": "odd"},
+                        "backgroundColor": "#2d4460",
+                    },
+                ],
+            )
+        )
+    elif result.success and result.df.empty:
+        children.append(
+            create_empty_state(
+                title="No Results",
+                message="The query returned no data. Try rephrasing your question.",
+                icon="bi-inbox",
+            )
+        )
+
+    # Collapsible SQL display
+    if result.sql:
+        children.append(
+            html.Details(
+                [
+                    html.Summary(
+                        "Generated SQL",
+                        style={"cursor": "pointer", "color": DARK_THEME["text_muted"]},
+                        className="mt-3 mb-2",
+                    ),
+                    html.Pre(
+                        result.sql,
+                        style={
+                            "backgroundColor": DARK_THEME["bg_darkest"],
+                            "color": DARK_THEME["text_secondary"],
+                            "padding": "12px",
+                            "borderRadius": "4px",
+                            "fontSize": "0.85em",
+                            "whiteSpace": "pre-wrap",
+                            "overflowX": "auto",
+                        },
+                    ),
+                ],
+                className="mt-2",
+            )
+        )
+
+    return html.Div(children)

--- a/uv.lock
+++ b/uv.lock
@@ -689,6 +689,23 @@ wheels = [
 ]
 
 [[package]]
+name = "groq"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/12/f4099a141677fcd2ed79dcc1fcec431e60c52e0e90c9c5d935f0ffaf8c0e/groq-1.0.0.tar.gz", hash = "sha256:66cb7bb729e6eb644daac7ce8efe945e99e4eb33657f733ee6f13059ef0c25a9", size = 146068, upload-time = "2025-12-17T23:34:23.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/88/3175759d2ef30406ea721f4d837bfa1ba4339fde3b81ba8c5640a96ed231/groq-1.0.0-py3-none-any.whl", hash = "sha256:6e22bf92ffad988f01d2d4df7729add66b8fd5dbfb2154b5bbf3af245b72c731", size = 138292, upload-time = "2025-12-17T23:34:21.957Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "24.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2294,6 +2311,7 @@ dependencies = [
     { name = "dash-cytoscape" },
     { name = "duckdb" },
     { name = "google-api-python-client" },
+    { name = "groq" },
     { name = "gunicorn" },
     { name = "lxml" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2326,6 +2344,7 @@ requires-dist = [
     { name = "dash-cytoscape", specifier = ">=1.0.2" },
     { name = "duckdb", specifier = ">=0.9.1" },
     { name = "google-api-python-client", specifier = ">=2.185.0" },
+    { name = "groq", specifier = ">=0.11.0" },
     { name = "gunicorn", specifier = ">=21.2.0" },
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary

- Adds a new `/chat` page with a natural language query interface powered by Groq (Llama 4 Scout)
- Users can ask questions about tournament data in plain English and get SQL-backed results displayed in a DataTable
- Includes a curated system prompt with 16 domain-specific rules and 5 example queries to guide SQL generation
- Fixes `territories.owner_player_id` to use global player IDs instead of per-match slot numbers, simplifying 10 query methods
- Adds an evaluation suite for regression testing the NL query system prompt

## Key changes

- **Chat page** (`pages/chat.py`, `data/nl_query.py`, `data/groq_client.py`): NL-to-SQL pipeline with Groq integration, read-only query execution, collapsible SQL display
- **Territory player ID fix** (`parser.py`, `etl.py`, `queries.py`): SQL UPDATE converted existing data; parser now accepts `player_id_mapping`; removed `player_order` CTE workaround from 10 query methods (-50 net lines)
- **System prompt rules**: Yield scale, game labels from players table, ROW_NUMBER for ties, aggregation guidance, uniqueness constraints, no data fabrication
- **Eval suite** (`scripts/eval_nl_query.py`, `scripts/eval_nl_fixtures.json`): 20 fixture queries with expected patterns for automated prompt regression testing

## Test plan

- [x] Run `uv run pytest tests/test_parser_territories.py -v` — all 15 tests pass
- [x] Run `uv run python scripts/validate_territories.py` — validation passes
- [x] Manually verify `/matches` page (Cities, Improvements, Science tabs) and Map Viewer
- [ ] Test chat queries: win rates, wonders, improvements, per-game peaks, cross-match aggregation
- [ ] Run eval suite: `uv run python scripts/eval_nl_query.py`